### PR TITLE
Replacing ibmcloud cli commands with oc commands

### DIFF
--- a/workshop/generatedContent/kube101/Lab1/README.md
+++ b/workshop/generatedContent/kube101/Lab1/README.md
@@ -52,7 +52,16 @@ In this part of the lab we will deploy an application called `guestbook` that ha
 
 1. `guestbook` is now running on your cluster, and exposed to the internet. We need to find out where it is accessible.
    The worker nodes running in the container service get external IP addresses.
-   Get the workers for your cluster and note one (any one) of the public IPs listed on the `<public-IP>` line. Replace `$CLUSTER_NAME` with your cluster name unless you have this environment variable set.
+   
+   Get the workers for your cluster and note one (any one) of the public IPs listed in the `<EXTERNAL-IP>` column.
+   
+   ```shell
+   NAME            STATUS   ROLES           AGE   VERSION           INTERNAL-IP     EXTERNAL-IP      OS-IMAGE   KERNEL-VERSION                CONTAINER-RUNTIME
+   10.189.80.112   Ready    master,worker   10d   v1.16.2+283af84   10.189.80.112   169.60.111.167   Red Hat    3.10.0-1127.13.1.el7.x86_64   cri-o://1.16.6-17.rhaos4.3.git4936f44.el7
+   10.189.80.113   Ready    master,worker   10d   v1.16.2+283af84   10.189.80.113   169.60.111.164   Red Hat    3.10.0-1127.13.1.el7.x86_64   cri-o://1.16.6-17.rhaos4.3.git4936f44.el7
+   ```
+   
+   <!-- Get the workers for your cluster and note one (any one) of the public IPs listed on the `<public-IP>` line. Replace `$CLUSTER_NAME` with your cluster name unless you have this environment variable set.
 
    ```shell
    $ ibmcloud ks workers --cluster $CLUSTER_NAME
@@ -61,10 +70,10 @@ In this part of the lab we will deploy an application called `guestbook` that ha
    kube-hou02-pa1e3ee39f549640aebea69a444f51fe55-w1   173.193.99.136   10.76.194.30   free           normal   Ready    hou02   1.5.6_1500*
    ```
 
-   We can see that our `<public-IP>` is `173.193.99.136`.
+   We can see that our `<public-IP>` is `173.193.99.136`. -->
 
 1. Now that you have both the address and the port, you can now access the application in the web browser
-   at `<public-IP>:<nodeport>`. In the example case this is `173.193.99.136:31208`.
+   at `<EXTERNAL-IP>:<nodeport>`. In the example case this is `169.60.111.167:31208`.
 
 Congratulations, you've now deployed an application to Kubernetes!
 

--- a/workshop/generatedContent/kube101/Lab1/README.md
+++ b/workshop/generatedContent/kube101/Lab1/README.md
@@ -56,6 +56,7 @@ In this part of the lab we will deploy an application called `guestbook` that ha
    Get the workers for your cluster and note one (any one) of the public IPs listed in the `<EXTERNAL-IP>` column.
    
    ```shell
+   $ oc get nodes -o wide
    NAME            STATUS   ROLES           AGE   VERSION           INTERNAL-IP     EXTERNAL-IP      OS-IMAGE   KERNEL-VERSION                CONTAINER-RUNTIME
    10.189.80.112   Ready    master,worker   10d   v1.16.2+283af84   10.189.80.112   169.60.111.167   Red Hat    3.10.0-1127.13.1.el7.x86_64   cri-o://1.16.6-17.rhaos4.3.git4936f44.el7
    10.189.80.113   Ready    master,worker   10d   v1.16.2+283af84   10.189.80.113   169.60.111.164   Red Hat    3.10.0-1127.13.1.el7.x86_64   cri-o://1.16.6-17.rhaos4.3.git4936f44.el7

--- a/workshop/generatedContent/kube101/Lab2/README.md
+++ b/workshop/generatedContent/kube101/Lab2/README.md
@@ -152,14 +152,14 @@ To update and roll back:
 1. Test the application as before, by accessing `<public-IP>:<nodeport>`
    in the browser to confirm your new code is active.
 
-   Remember, to get the "nodeport" and "public-ip" use the following commands. Replace `$CLUSTER_NAME` with the name of your cluster if the environment variable is not set.:
+   Remember, to get the "nodeport" and "EXTERNAL-IP" use the following commands.:
 
    ```shell
    oc describe service guestbook
    ```
    and
    ```shell
-   ibmcloud ks workers --cluster $CLUSTER_NAME
+   oc get nodes -o wide
    ```
 
    To verify that you're running "v2" of guestbook, look at the title of the page,

--- a/workshop/generatedContent/kube101/Lab3/README.md
+++ b/workshop/generatedContent/kube101/Lab3/README.md
@@ -1,6 +1,6 @@
 # Lab 3: Scale and update apps natively, building multi-tier applications.
 
-In this lab you'll learn how to deploy the same guestbook application we deployed in the previous labs, however, instead of using the `kubectl` command line helper functions we'll be deploying the application using configuration files. The configuration file mechanism allows you to have more fine-grained control over all of resources being created within the Kubernetes cluster.
+In this lab you'll learn how to deploy the same guestbook application we deployed in the previous labs, however, instead of using the `oc` command line helper functions we'll be deploying the application using configuration files. The configuration file mechanism allows you to have more fine-grained control over all of resources being created within the Kubernetes cluster.
 
 Before we work with the application we need to clone a github repo:
 
@@ -132,7 +132,7 @@ The above configuration creates a Service resource named guestbook. A Service ca
 - Test guestbook app using a browser of your choice using the url
   `<your-cluster-ip>:<node-port>`
 
-  Remember, to get the `nodeport` and `public-ip` use the following commands, replacing `$CLUSTER_NAME` with the name of your cluster if the environment variable is not already set.
+  Remember, to get the `nodeport` and `EXTERNAL-IP` use the following commands.
 
   ```shell
   oc describe service guestbook
@@ -140,7 +140,7 @@ The above configuration creates a Service resource named guestbook. A Service ca
   and
 
   ```shell 
-  ibmcloud ks workers --cluster $CLUSTER_NAME
+  oc get nodes -o wide
   ```
 
 # 2. Connect to a back-end service.


### PR DESCRIPTION
Replaced `ibmcloud ks workers --cluster $CLUSTER_NAME` with `oc get nodes -o wide`. It makes the workshop smoother as the user does not need to sign in to the ibmcloud cli or find their own cluster name and the `oc` command is consistent with the rest of the labs.